### PR TITLE
Added missing code to properly support maximum file length. 

### DIFF
--- a/StyleCopPlus/Plugin/MoreCustom/CustomRulesSettings.cs
+++ b/StyleCopPlus/Plugin/MoreCustom/CustomRulesSettings.cs
@@ -33,6 +33,11 @@ namespace StyleCopPlus.Plugin.MoreCustom
 		public LimitOptionsData PropertySizeOptions { get; private set; }
 
 		/// <summary>
+		/// Gets file size options.
+		/// </summary>
+		public LimitOptionsData FileSizeOptions { get; private set; }
+
+		/// <summary>
 		/// Initializes settings from specified document.
 		/// </summary>
 		public void Initialize(SourceAnalyzer analyzer, CodeDocument document)
@@ -61,6 +66,11 @@ namespace StyleCopPlus.Plugin.MoreCustom
 				analyzer,
 				document,
 				Rules.PropertyMustNotContainMoreLinesThan);
+
+			FileSizeOptions = GetOptionsData<LimitOptionsData>(
+				analyzer,
+				document,
+				Rules.FileMustNotContainMoreLinesThan);
 		}
 
 		/// <summary>

--- a/StyleCopPlus/Plugin/MoreCustom/MoreCustomRules.cs
+++ b/StyleCopPlus/Plugin/MoreCustom/MoreCustomRules.cs
@@ -67,6 +67,16 @@ namespace StyleCopPlus.Plugin.MoreCustom
 				CheckLineLength(document, currentLine, currentLineNumber, settings);
 			}
 
+			if (lines.Count > settings.FileSizeOptions.Limit.Value)
+			{
+				AddViolation(
+					document,
+					1,
+					Rules.FileMustNotContainMoreLinesThan,
+					settings.FileSizeOptions.Limit.Value,
+					lines.Count);
+			}
+
 			CheckLastLine(document, source, lines.Count, settings);
 		}
 


### PR DESCRIPTION
Whilst there is a configuration item for maximum file length within StyleCop+, there is no code to support it. I have added suitable code to implement this feature therefore.
