### PR TITLE
Fixed multi-line comments being mistaken for source code indentions

### DIFF
--- a/StyleCopPlus.Tests/Complex/Source/Environmental.cs
+++ b/StyleCopPlus.Tests/Complex/Source/Environmental.cs
@@ -170,6 +170,17 @@ namespace StyleCopPlus.Tests
 }
 //# [END]
 
+//# [OK]
+//# Don't count aligned * as indention errors.
+namespace StyleCopPlus.Tests
+{
+	/*
+	 * multi-line
+	 * comment
+	 */
+}
+//# [END]
+
 #endregion
 
 #region CheckWhetherLastCodeLineIsEmpty // Suppressing

--- a/StyleCopPlus/Plugin/MoreCustom/MoreCustomRules.cs
+++ b/StyleCopPlus/Plugin/MoreCustom/MoreCustomRules.cs
@@ -101,7 +101,12 @@ namespace StyleCopPlus.Plugin.MoreCustom
 			int currentLineNumber,
 			CustomRulesSettings settings)
 		{
-			if (currentLine.Trim().Length == 0)
+			string trimmed = currentLine.Trim();
+
+			if (trimmed.Length == 0)
+				return;
+
+			if (trimmed.StartsWith("*"))
 				return;
 
 			string currentIndent = ExtractIndentation(currentLine);


### PR DESCRIPTION
as described in https://stylecopplus.codeplex.com/workitem/9348.
